### PR TITLE
Fix ReasonML match pattern

### DIFF
--- a/icon_associations.json
+++ b/icon_associations.json
@@ -3512,7 +3512,7 @@
 					"fileNames": "*.re,*.rei",
 					"name": "ReasonML",
 					"color": "D52A29",
-					"pattern": ".*\\.rei?",
+					"pattern": ".*\\.rei?$",
 					"icon": "/icons/files/reason.svg"
 				},
 				{


### PR DESCRIPTION
In mallowigi/a-file-icon-web#4 I forgot `icon_associations.json` is pulled from this repository, so I should make changes here instead. Sorry for the inconvenience!