### PR TITLE
handle `babel.config.js` and `eslintrc.cjs`

### DIFF
--- a/icon_associations.xml
+++ b/icon_associations.xml
@@ -554,10 +554,10 @@
                color="F59F29"
                pattern="^\.(babelrc(\.js)?|languagebabel|babel)$"
                icon="/icons/files/babel.svg" />
-        <regex fileNames="babel.json,babel.config.json"
+        <regex fileNames="babel.json,babel.config.json,babel.config.js"
                name="Babel Config"
                color="F59F29"
-               pattern="^babel(\.[\w\-]+)?\.json$"
+               pattern="^babel(\.[\w\-]+)?\.js(on)$"
                icon="/icons/files/babel.svg" />
         <regex fileNames="backbone.js,backbone.min.js"
                name="Backbone"
@@ -1573,10 +1573,10 @@
                color="e55151"
                pattern="^\.esdoc\.([cm]?js|json)$"
                icon="/icons/files/esdoc.svg" />
-        <regex fileNames=".eslintrc,.eslintrc.js,.eslintrc.json,.eslintrc.yml"
+        <regex fileNames=".eslintrc,.eslintrc.js,.eslintrc.cjs,.eslintrc.json,.eslintrc.yml"
                name="ESLint"
                color="7963E6"
-               pattern=".*\.eslintrc(\.js(on)?|\.y(a)?ml)?$"
+               pattern=".*\.eslintrc(\.(c)js(on)?|\.y(a)?ml)?$"
                icon="/icons/files/eslint.svg" />
         <regex fileNames=".eslintcache"
                name="ESLint Cache"
@@ -4884,8 +4884,8 @@
         <!--endregion-->
 
         <!--<regex fileNames=""
- name="Any" 
-pattern="" 
+ name="Any"
+pattern=""
 icon="/icons/files/default.svg"/>-->
     </associations>
 </associations>

--- a/icon_associations.xml
+++ b/icon_associations.xml
@@ -554,10 +554,10 @@
                color="F59F29"
                pattern="^\.(babelrc(\.js)?|languagebabel|babel)$"
                icon="/icons/files/babel.svg" />
-        <regex fileNames="babel.json,babel.config.json,babel.config.js"
+        <regex fileNames="babel.json,babel.config.json,babel.config.js,babel.config.mjs,babel.config.cjs"
                name="Babel Config"
                color="F59F29"
-               pattern="^babel(\.[\w\-]+)?\.js(on)$"
+               pattern="^babel(\.[\w\-]+)?\.[cm]?js(on)?$"
                icon="/icons/files/babel.svg" />
         <regex fileNames="backbone.js,backbone.min.js"
                name="Backbone"
@@ -1573,10 +1573,10 @@
                color="e55151"
                pattern="^\.esdoc\.([cm]?js|json)$"
                icon="/icons/files/esdoc.svg" />
-        <regex fileNames=".eslintrc,.eslintrc.js,.eslintrc.cjs,.eslintrc.json,.eslintrc.yml"
+        <regex fileNames=".eslintrc,.eslintrc.js,.eslintrc.mjs,.eslintrc.cjs,.eslintrc.json,.eslintrc.yml"
                name="ESLint"
                color="7963E6"
-               pattern=".*\.eslintrc(\.(c)js(on)?|\.y(a)?ml)?$"
+               pattern=".*\.eslintrc(\.[cm]?js(on)?|\.y(a)?ml)?$"
                icon="/icons/files/eslint.svg" />
         <regex fileNames=".eslintcache"
                name="ESLint Cache"


### PR DESCRIPTION
1. Babel config can also be done using js files and hence they should be given the appropriate icons
2. In projects using the latest ESModule instead of commonjs, using `.eslintrc.js` causes issues. This is because some dependency might be calling `.eslintrc.js` as a commonjs module. To work around this, the recommendation is to rename the file to `.eslintrc.cjs`. This is now handled in the PR.

I have only modified the xml. If needed I can run `npm run convert` to generate the jsons and create a new commit in this PR. Let me know.