### PR TITLE
Fix typo in Test JS pattern

### DIFF
--- a/icon_associations.json
+++ b/icon_associations.json
@@ -11034,7 +11034,7 @@
 					"color": "E79627",
 					"priority": "100",
 					"iconType": "FILE",
-					"pattern": ".*\\.?(test|spec)\\.[cm](js|es6)$",
+					"pattern": ".*\\.?(test|spec)\\.[cm]?(js|es6)$",
 					"icon": "/icons/files/testjs.svg"
 				},
 				{


### PR DESCRIPTION
Test file icons for JS/ES didn't show. Instead, regular JS icon was used.