### PR TITLE
Handle .flattened-pom.xml (Maven)

### DIFF
--- a/icon_associations.xml
+++ b/icon_associations.xml
@@ -5431,12 +5431,12 @@
                iconType="FILE"
                pattern="^(MathJax[^.]*|TeX-MML-AM_CHTML)\.[cm]?js$"
                icon="/icons/files/mathjax.svg" />
-        <regex fileNames="pom.xml"
+        <regex fileNames="pom.xml,.flattened-pom.xml"
                name="Maven"
                color="F13C6F"
                priority="100"
                iconType="FILE"
-               pattern="^pom\.xml$"
+               pattern="^(\.flattened-)?pom\.xml$"
                url="https://maven.apache.org/"
                icon="/icons/files/maven.svg" />
         <regex fileNames="*.maxpat,*.maxobj,*.maxproj,*.maxhelp,*.pat,*.mxt"


### PR DESCRIPTION
Added `.flattened-pom.xml` icon association (generated by the maven-flatten-plugin)