### PR TITLE
Add another association for Hugo

### DIFF
--- a/icon_associations.json
+++ b/icon_associations.json
@@ -6344,6 +6344,16 @@
           "icon": "/icons/files/hugo.svg"
         },
         {
+          "fileNames": "hugo.toml",
+          "name": "Hugo",
+          "iconColor": "fe4088",
+          "url": "https://gohugo.io/",
+          "priority": "100",
+          "iconType": "FILE",
+          "pattern": "hugo\\.toml$",
+          "icon": "/icons/files/hugo.svg"
+        },
+        {
           "fileNames": "*.aff,*.dic",
           "name": "Hunspell",
           "iconColor": "7cb342",

--- a/icon_associations.xml
+++ b/icon_associations.xml
@@ -5128,6 +5128,14 @@
            iconType="FILE"
            pattern="config\.toml$"
            icon="/icons/files/hugo.svg"/>
+    <regex fileNames="hugo.toml"
+           name="Hugo"
+           iconColor="fe4088"
+           url="https://gohugo.io/"
+           priority="100"
+           iconType="FILE"
+           pattern="hugo\.toml$"
+           icon="/icons/files/hugo.svg"/>
     <regex fileNames="*.aff,*.dic"
            name="Hunspell"
            iconColor="7cb342"


### PR DESCRIPTION
Hugo v0.111.0 added a new default configuration file named `hugo.toml` instead of the presently used `config.toml`: https://gohugo.io/getting-started/configuration/#hugotoml-vs-configtoml. This PR adds support for the new file name to show the Hugo icon by default.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>